### PR TITLE
increasing compatibility with foreach+curl_setopt

### DIFF
--- a/php5/OAuth2Client.php
+++ b/php5/OAuth2Client.php
@@ -501,7 +501,11 @@ abstract class OAuth2Client {
     
     if ($this->debug) print('path = '.$path);
     if ($this->debug) print('curl_opts = '.print_r($opts,true));
-    curl_setopt_array($ch, $opts);
+    //curl_setopt_array($ch, $opts);
+    // silly as it is, the foreach loop increases compatibility
+    foreach ($opts as $key => $value) {
+      curl_setopt($ch, $key, $value);
+    }
     $result = curl_exec($ch);
     if ($this->debug) print("RESULT =\n".$result);
     if (curl_errno($ch) == 60) { // CURLE_SSL_CACERT


### PR DESCRIPTION
Just deployed a well-tested app to a vanilla PHP instance on AppFog, which is a Cloud Foundry provider. MailChimp integration went from rock solid to fully broken. After wrestling with it I found the culprit to be curl_setopt_array on line 504 here. For some reason it just wasn't setting the URL properly, causing a "No URL set!" curl error.

I know it's not your code, but this fixed everything immediately. I re-ran our tests and verified that it didn't break the local copy that was previously working, and it didn't cause any noticeable slow-down. 

Figured a quickie patch might let you guys focus on MailChimp examples instead of trying to debug this one for the next person who spins up an AppFog/Cloud Foundry instance to try things out.
